### PR TITLE
support data type in checkbox and radio 

### DIFF
--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -152,9 +152,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val value = formParameter.getString("value")
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
-            if ((type == "radio" || type == "checkbox") && !checked) {
-
-            } else {
+            if (!abandon(type, checked)) {
                 map[name] = value
             }
         }
@@ -172,9 +170,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val type = formParameter.getString("type")
             val encodedValue = URLEncoder.encode(value, "UTF-8")
 
-            if ((type == "radio" || type == "checkbox") && !checked) {
-
-            } else {
+            if (!abandon(type, checked)) {
                 if (i != 0) {
                     resultStringBuilder.append("&")
                 }
@@ -197,8 +193,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if ((type == "radio" || type == "checkbox") && !checked) {
-            } else {
+            if (!abandon(type, checked)) {
                 resultStringBuilder.append("--")
                 resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
                 resultStringBuilder.append("\n")
@@ -224,8 +219,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if ((type == "radio" || type == "checkbox") && !checked) {
-            } else {
+            if (!abandon(type, checked)) {
                 if (i != 0) {
                     resultStringBuilder.append("\n")
                 }
@@ -236,6 +230,10 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
 
         }
         return resultStringBuilder.toString()
+    }
+
+    private fun abandon(type: String, checked: Boolean): Boolean {
+        return (type == "radio" || type == "checkbox") && !checked
     }
 
     companion object {

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -162,13 +162,21 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val formParameter = formParameterJsonArray.get(i) as JSONObject
             val name = formParameter.getString("name")
             val value = formParameter.getString("value")
+            val checked = formParameter.optBoolean("checked")
+            val type = formParameter.getString("type")
             val encodedValue = URLEncoder.encode(value, "UTF-8")
             if (i != 0) {
                 resultStringBuilder.append("&")
             }
-            resultStringBuilder.append(name)
-            resultStringBuilder.append("=")
-            resultStringBuilder.append(encodedValue)
+            if (type == "radio" && !checked) {
+
+            } else {
+                resultStringBuilder.append(name)
+                resultStringBuilder.append("=")
+                resultStringBuilder.append(encodedValue)
+            }
+
+
         }
         return resultStringBuilder.toString()
     }

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -224,7 +224,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if (type == "radio" && !checked) {
+            if ((type == "radio" || type == "checkbox") && !checked) {
             } else {
                 if (i != 0) {
                     resultStringBuilder.append("\n")

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -152,7 +152,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val value = formParameter.getString("value")
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
-            if (type == "radio" && !checked) {
+            if ((type == "radio" || type == "checkbox") && !checked) {
 
             } else {
                 map[name] = value
@@ -172,7 +172,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val type = formParameter.getString("type")
             val encodedValue = URLEncoder.encode(value, "UTF-8")
 
-            if (type == "radio" && !checked) {
+            if ((type == "radio" || type == "checkbox") && !checked) {
 
             } else {
                 if (i != 0) {
@@ -197,7 +197,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if (type == "radio"&&!checked) {
+            if ((type == "radio" || type == "checkbox") && !checked) {
             } else {
                 resultStringBuilder.append("--")
                 resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
@@ -224,7 +224,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if (type == "radio"&&!checked) {
+            if (type == "radio" && !checked) {
             } else {
                 if (i != 0) {
                     resultStringBuilder.append("\n")

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -152,7 +152,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val value = formParameter.getString("value")
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
-            if (!abandon(type, checked)) {
+            if (!isExcludedFormParameter(type, checked)) {
                 map[name] = value
             }
         }
@@ -170,7 +170,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val type = formParameter.getString("type")
             val encodedValue = URLEncoder.encode(value, "UTF-8")
 
-            if (!abandon(type, checked)) {
+            if (!isExcludedFormParameter(type, checked)) {
                 if (i != 0) {
                     resultStringBuilder.append("&")
                 }
@@ -193,7 +193,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if (!abandon(type, checked)) {
+            if (!isExcludedFormParameter(type, checked)) {
                 resultStringBuilder.append("--")
                 resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
                 resultStringBuilder.append("\n")
@@ -219,7 +219,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if (!abandon(type, checked)) {
+            if (!isExcludedFormParameter(type, checked)) {
                 if (i != 0) {
                     resultStringBuilder.append("\n")
                 }
@@ -232,7 +232,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
         return resultStringBuilder.toString()
     }
 
-    private fun abandon(type: String, checked: Boolean): Boolean {
+    private fun isExcludedFormParameter(type: String, checked: Boolean): Boolean {
         return (type == "radio" || type == "checkbox") && !checked
     }
 

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -150,6 +150,13 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val formParameter = formParameterJsonArray.get(i) as JSONObject
             val name = formParameter.getString("name")
             val value = formParameter.getString("value")
+            val checked = formParameter.optBoolean("checked")
+            val type = formParameter.getString("type")
+            if (type == "radio" && !checked) {
+
+            } else {
+                map[name] = value
+            }
             map[name] = value
         }
         return map

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -172,12 +172,13 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
             val encodedValue = URLEncoder.encode(value, "UTF-8")
-            if (i != 0) {
-                resultStringBuilder.append("&")
-            }
+
             if (type == "radio" && !checked) {
 
             } else {
+                if (i != 0) {
+                    resultStringBuilder.append("&")
+                }
                 resultStringBuilder.append(name)
                 resultStringBuilder.append("=")
                 resultStringBuilder.append(encodedValue)
@@ -197,16 +198,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
-            if (type == "radio") {
-                if (checked) {
-                    resultStringBuilder.append("--")
-                    resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
-                    resultStringBuilder.append("\n")
-                    resultStringBuilder.append("Content-Disposition: form-data; name=\"$name\"")
-                    resultStringBuilder.append("\n\n")
-                    resultStringBuilder.append(value)
-                    resultStringBuilder.append("\n")
-                }
+            if (type == "radio"&&!checked) {
             } else {
                 resultStringBuilder.append("--")
                 resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
@@ -232,16 +224,12 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val value = formParameter.getString("value")
             val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
-            if (i != 0) {
-                resultStringBuilder.append("\n")
-            }
-            if (type == "radio") {
-                if (checked) {
-                    resultStringBuilder.append(name)
-                    resultStringBuilder.append("=")
-                    resultStringBuilder.append(value)
-                }
+
+            if (type == "radio"&&!checked) {
             } else {
+                if (i != 0) {
+                    resultStringBuilder.append("\n")
+                }
                 resultStringBuilder.append(name)
                 resultStringBuilder.append("=")
                 resultStringBuilder.append(value)

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -179,11 +179,11 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val formParameter = formParameterJsonArray.get(i) as JSONObject
             val name = formParameter.getString("name")
             val value = formParameter.getString("value")
-            val checked = formParameter.getString("checked")
+            val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
 
             if (type == "radio") {
-                if (checked == "checked") {
+                if (checked) {
                     resultStringBuilder.append("--")
                     resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
                     resultStringBuilder.append("\n")
@@ -215,13 +215,13 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val formParameter = formParameterJsonArray.get(i) as JSONObject
             val name = formParameter.getString("name")
             val value = formParameter.getString("value")
-            val checked = formParameter.getString("checked")
+            val checked = formParameter.optBoolean("checked")
             val type = formParameter.getString("type")
             if (i != 0) {
                 resultStringBuilder.append("\n")
             }
             if (type == "radio") {
-                if (checked == "checked") {
+                if (checked) {
                     resultStringBuilder.append(name)
                     resultStringBuilder.append("=")
                     resultStringBuilder.append(value)

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -179,13 +179,29 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val formParameter = formParameterJsonArray.get(i) as JSONObject
             val name = formParameter.getString("name")
             val value = formParameter.getString("value")
-            resultStringBuilder.append("--")
-            resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
-            resultStringBuilder.append("\n")
-            resultStringBuilder.append("Content-Disposition: form-data; name=\"$name\"")
-            resultStringBuilder.append("\n\n")
-            resultStringBuilder.append(value)
-            resultStringBuilder.append("\n")
+            val checked = formParameter.getString("checked")
+            val type = formParameter.getString("type")
+
+            if (type == "radio") {
+                if (checked == "checked") {
+                    resultStringBuilder.append("--")
+                    resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
+                    resultStringBuilder.append("\n")
+                    resultStringBuilder.append("Content-Disposition: form-data; name=\"$name\"")
+                    resultStringBuilder.append("\n\n")
+                    resultStringBuilder.append(value)
+                    resultStringBuilder.append("\n")
+                }
+            } else {
+                resultStringBuilder.append("--")
+                resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
+                resultStringBuilder.append("\n")
+                resultStringBuilder.append("Content-Disposition: form-data; name=\"$name\"")
+                resultStringBuilder.append("\n\n")
+                resultStringBuilder.append(value)
+                resultStringBuilder.append("\n")
+            }
+
         }
         resultStringBuilder.append("--")
         resultStringBuilder.append(MULTIPART_FORM_BOUNDARY)
@@ -199,12 +215,23 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             val formParameter = formParameterJsonArray.get(i) as JSONObject
             val name = formParameter.getString("name")
             val value = formParameter.getString("value")
+            val checked = formParameter.getString("checked")
+            val type = formParameter.getString("type")
             if (i != 0) {
                 resultStringBuilder.append("\n")
             }
-            resultStringBuilder.append(name)
-            resultStringBuilder.append("=")
-            resultStringBuilder.append(value)
+            if (type == "radio") {
+                if (checked == "checked") {
+                    resultStringBuilder.append(name)
+                    resultStringBuilder.append("=")
+                    resultStringBuilder.append(value)
+                }
+            } else {
+                resultStringBuilder.append(name)
+                resultStringBuilder.append("=")
+                resultStringBuilder.append(value)
+            }
+
         }
         return resultStringBuilder.toString()
     }
@@ -230,11 +257,15 @@ function recordFormSubmission(form) {
         var parName = form.elements[i].name;
         var parValue = form.elements[i].value;
         var parType = form.elements[i].type;
+        var parChecked = form.elements[i].checked;
+        var parId = form.elements[i].id;
 
         jsonArr.push({
             name: parName,
             value: parValue,
-            type: parType
+            type: parType,
+            checked:parChecked,
+            id:parId
         });
     }
 

--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -157,7 +157,6 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
             } else {
                 map[name] = value
             }
-            map[name] = value
         }
         return map
     }


### PR DESCRIPTION
在旧的拦截数据中，一些选项会有多个单选框从而造成数据重复，因此在最终生成form表单时导致数据被最后一个重复数据覆盖，最终导致请求数据与页面显示的应提交数据不一致。
In the old interception data, some options will have multiple radio button boxes, causing data duplication. Therefore, when the form is finally generated, the data will be overwritten by the last duplicate data, which ultimately leads to inconsistency between the request data and the data that should be submitted displayed on the page.
[例子/example](https://github.com/xiaojieonly/Ehviewer_CN_SXJ/blob/BiLi_PC_Gamer/app/src/test/resources/com/hippo/ehviewer/client/parser/EhUconfig.html)
