### PR TITLE
Just record on window submit form event

### DIFF
--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -293,7 +293,8 @@ function handleFormSubmission(e) {
 HTMLFormElement.prototype._submit = HTMLFormElement.prototype.submit;
 HTMLFormElement.prototype.submit = handleFormSubmission;
 window.addEventListener('submit', function (submitEvent) {
-    handleFormSubmission(submitEvent);
+    const form = submitEvent ? submitEvent.target : this;
+    recordFormSubmission(form);
 }, true);
 
 let lastXmlhttpRequestPrototypeMethod = null;


### PR DESCRIPTION
The window submit form event should be handled on web client side. Normally, they need to check some logic before submit it to server. So if we call `form.submit()` on that listener will cause some exception cases.