### PR TITLE
fix casing for HTTP headers by removing locale dependency

### DIFF
--- a/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
+++ b/app/src/main/java/com/acsbendi/requestinspectorwebview/RequestInspectorJavaScriptInterface.kt
@@ -7,7 +7,6 @@ import org.intellij.lang.annotations.Language
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URLEncoder
-import java.util.Locale
 
 internal class RequestInspectorJavaScriptInterface(webView: WebView) {
 
@@ -138,7 +137,7 @@ internal class RequestInspectorJavaScriptInterface(webView: WebView) {
         val headersObject = JSONObject(headersString)
         val map = HashMap<String, String>()
         for (key in headersObject.keys()) {
-            val lowercaseHeader = key.lowercase(Locale.getDefault())
+            val lowercaseHeader = key.lowercase()
             map[lowercaseHeader] = headersObject.getString(key)
         }
         return map


### PR DESCRIPTION
Previously, explicitly using Locale.getDefault() made string transformations dependent on the device's language settings. This caused issues in certain locales (e.g. Turkish), where characters like 'I' are transformed incorrectly (to dotless 'ı'), creating invalid HTTP headers.

This change switches to the parameterless lowercase(), which implicitly uses the locale-agnostic Root locale, ensuring header keys remain valid regardless of user settings.